### PR TITLE
New track for humble_gzharmonic

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -1,4 +1,24 @@
 tracks:
+  humble_gzharmonic:
+    actions:
+    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
+      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
+    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
+      --replace
+    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
+    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+      -i :{release_inc} --os-name ubuntu
+    devel_branch: humble
+    last_version: 0.244.12
+    name: upstream
+    patches: null
+    release_inc: '0'
+    release_repo_url: null
+    release_tag: :{version}
+    ros_distro: humble
+    vcs_type: git
+    vcs_uri: https://github.com/gazebosim/ros_gz
+    version: :{auto}
   iron_gzharmonic:
     actions:
     - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri


### PR DESCRIPTION
Implementing the track to support humble_gzharmonic combinations:
  * Reduced the number of generators excluding rpm and debian
  * Branch in ros_gz repository is: `humble`
  * Set the version to the latest in the `ros_gz` repo.